### PR TITLE
Upgrade hive in docker image to 2.3.4 by using EMR repos for 5.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [1.3.0] - 2019-09-09
 
 ### Changed
-- Updated `emr-apps.repo` to 5.24.0.
-- Updated `emr-platform.repo` to 1.17.0
+- Updated `emr-apps.repo` to `5.24.0` (was `5.15.0`).
+- Updated `emr-platform.repo` to `1.17.0` (was `1.6.0`).
 
 ### Fixed
 - Upgrade Hive to 2.3.4 in order to fix
-  https://issues.apache.org/jira/browse/HIVE-18767 - see [#59](https://github.com/ExpediaGroup/apiary-metastore-docker/issues/59)
+  https://issues.apache.org/jira/browse/HIVE-18767 - see
+  [#59](https://github.com/ExpediaGroup/apiary-metastore-docker/issues/59)
+  (Hive version is controlled by the version of `emr-apps.repo`).
 
 ## [1.2.0] - 2019-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2019-09-09
+
+### Changed
+- Updated `emr-apps.repo` to 5.24.0.
+- Updated `emr-platform.repo` to 1.17.0
+
+### Fixed
+- Upgrade Hive to 2.3.4 in order to fix
+  https://issues.apache.org/jira/browse/HIVE-18767 - see [#59](https://github.com/ExpediaGroup/apiary-metastore-docker/issues/59)
+
 ## [1.2.0] - 2019-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Updated `emr-platform.repo` to `1.17.0` (was `1.6.0`).
 
 ### Fixed
-- Upgrade Hive to 2.3.4 in order to fix
+- Upgrade Hive to `2.3.4` (was `2.3.3`) in order to fix
   https://issues.apache.org/jira/browse/HIVE-18767 - see
   [#59](https://github.com/ExpediaGroup/apiary-metastore-docker/issues/59)
   (Hive version is controlled by the version of `emr-apps.repo`).

--- a/files/emr-apps.repo
+++ b/files/emr-apps.repo
@@ -2,6 +2,6 @@
 name = EMR Applications Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3-us-west-2.amazonaws.com/repo.us-west-2.emr.amazonaws.com/apps-repository/emr-5.24.0/a536ac12-f2f9-43e2-88ae-1a1e6d740eb9
+baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.24.0/a536ac12-f2f9-43e2-88ae-1a1e6d740eb9
 priority = 5
 gpgcheck = 1

--- a/files/emr-apps.repo
+++ b/files/emr-apps.repo
@@ -2,6 +2,6 @@
 name = EMR Applications Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.15.0/0f8b1ac0-a4a0-46e2-afe8-6ac5828e4da8
+baseurl = https://s3-us-west-2.amazonaws.com/repo.us-west-2.emr.amazonaws.com/apps-repository/emr-5.24.0/a536ac12-f2f9-43e2-88ae-1a1e6d740eb9
 priority = 5
 gpgcheck = 1

--- a/files/emr-platform.repo
+++ b/files/emr-platform.repo
@@ -2,6 +2,6 @@
 name = EMR Platform Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3-us-west-2.amazonaws.com/repo.us-west-2.emr.amazonaws.com/platform-repository/1.17.0/a2676858-5c70-4eb2-b063-5bb11ea995b1
+baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/platform-repository/1.17.0/a2676858-5c70-4eb2-b063-5bb11ea995b1
 priority = 5
 gpgcheck = 1

--- a/files/emr-platform.repo
+++ b/files/emr-platform.repo
@@ -2,6 +2,6 @@
 name = EMR Platform Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/platform-repository/1.6.0/65edd94e-45e5-42ad-9559-0bd1d21127bf
+baseurl = https://s3-us-west-2.amazonaws.com/repo.us-west-2.emr.amazonaws.com/platform-repository/1.17.0/a2676858-5c70-4eb2-b063-5bb11ea995b1
 priority = 5
 gpgcheck = 1


### PR DESCRIPTION
Fixes issue #59 

Tested in EG account `dsp-test`.  HMS came up successfully, and I was able to run a variety of hive commands that worked just as they do in Hive 2.3.3.

Saw following logs in cloudwatch:
```
21:22:20 STARTUP_MSG: Starting HiveMetaStore
21:22:20 STARTUP_MSG: version = 2.3.4-amzn-2
```