### PR TITLE
[Issue 165] Add init container docker image for HMS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - TBD
+### Added
+- [Issue-165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165) Add init container dockerfile for supporting air-gapped environments.
+
 ## [1.15.0] - 2020-06-16
 ### Added
 Create Hive database `apiary_system` on startup. Data for Ranger access logs goes to bucket `<prefix>-apiary-system` in Parquet format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.16.0] - TBD
+## [1.16.0] - 2020-08-31
 ### Added
 - [Issue-165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165) Add init container dockerfile for supporting air-gapped environments.
 

--- a/initContainer/Dockerfile
+++ b/initContainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.9
+
+RUN apk add --no-cache mariadb-client jq
+RUN addgroup -S apiary && adduser -S apiary -G apiary -H
+
+ADD --chown=apiary:apiary *.sh /init/
+WORKDIR /init
+RUN chmod +x `ls *.sh`
+USER apiary
+
+CMD ["/bin/sh"]

--- a/initContainer/README.md
+++ b/initContainer/README.md
@@ -15,7 +15,7 @@ The init docker container contains the same shell scripts which were previously 
 
 - Kubernetes
   - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/master/k8s-readonly.tf#L40)
-  - [Read-Write](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/k8s-readwrite.tf#L40)
+  - [Read-Write](https://github.com/ExpediaGroup/apiary-data-lake/blob/master/k8s-readwrite.tf#L40)
 - ECS
-  - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/templates/apiary-hms-readonly.json#L2)
-  - [Read-Write](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/templates/apiary-hms-readwrite.json#L2)
+  - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/master/templates/apiary-hms-readonly.json#L2)
+  - [Read-Write](https://github.com/ExpediaGroup/apiary-data-lake/blob/master/templates/apiary-hms-readwrite.json#L2)

--- a/initContainer/README.md
+++ b/initContainer/README.md
@@ -1,6 +1,6 @@
 # Apiary Init Container
 
-This container was introduced as apart of resolving [[Issue 165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165)]. 
+This container was introduced as a part of resolving [[Issue 165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165)]. 
 The general idea of why this container exists was to remove external dependencies and networking requirements between a deployment server and the deployment target when deploying Apiary. 
 
 Previously, Apiary had a hard requirement that the location of where the terraform apply job was running, had to have direct network access to the MySQL database in order to properly configure account access for the read-only and read-write roles. This presented some challenges when deploying into air-gapped environments as there would be no direct network access without punching a hole or proxying a connection between the deployer and the deployment environment.
@@ -14,7 +14,7 @@ The init docker container contains the same shell scripts which were previously 
 ## Terraform Usages
 
 - Kubernetes
-  - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/k8s-readonly.tf#L40)
+  - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/master/k8s-readonly.tf#L40)
   - [Read-Write](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/k8s-readwrite.tf#L40)
 - ECS
   - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/templates/apiary-hms-readonly.json#L2)

--- a/initContainer/README.md
+++ b/initContainer/README.md
@@ -8,7 +8,7 @@ Previously, Apiary had a hard requirement that the location of where the terrafo
 This solution relies on either [Kubernetes Init Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) or [ECS Container dependencies](https://aws.amazon.com/about-aws/whats-new/2019/03/amazon-ecs-introduces-enhanced-container-dependency-management/), depending on your deployment target.
 
 
-The init docker container contains the same shell scripts which were previously ran as apart of the apiary terraform process.
+The init docker container contains the same shell scripts which were previously run as a part of the apiary terraform process.
 
 
 ## Terraform Usages

--- a/initContainer/README.md
+++ b/initContainer/README.md
@@ -1,0 +1,21 @@
+# Apiary Init Container
+
+This container was introduced as apart of resolving [[Issue 165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165)]. 
+The general idea of why this container exists was to remove external dependencies and networking requirements between a deployment server and the deployment target when deploying Apiary. 
+
+Previously, Apiary had a hard requirement that the location of where the terraform apply job was running, had to have direct network access to the MySQL database in order to properly configure account access for the read-only and read-write roles. This presented some challenges when deploying into air-gapped environments as there would be no direct network access without punching a hole or proxying a connection between the deployer and the deployment environment.
+
+This solution relies on either [Kubernetes Init Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) or [ECS Container dependencies](https://aws.amazon.com/about-aws/whats-new/2019/03/amazon-ecs-introduces-enhanced-container-dependency-management/), depending on your deployment target.
+
+
+The init docker container contains the same shell scripts which were previously ran as apart of the apiary terraform process.
+
+
+## Terraform Usages
+
+- Kubernetes
+  - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/k8s-readonly.tf#L40)
+  - [Read-Write](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/k8s-readwrite.tf#L40)
+- ECS
+  - [Read-Only](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/templates/apiary-hms-readonly.json#L2)
+  - [Read-Write](https://github.com/ExpediaGroup/apiary-data-lake/blob/9881ef5b6fdb37bd22ca132542104f7eb026ce0c/templates/apiary-hms-readwrite.json#L2)

--- a/initContainer/allow-grant.sh
+++ b/initContainer/allow-grant.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+MYSQL_USER=$(echo "$MYSQL_USER_CREDS" | jq -r .username);
+MYSQL_PASSWORD=$(echo "$MYSQL_USER_CREDS" | jq -r .password);
+MYSQL_MASTER_USER=$(echo "$MYSQL_MASTER_CREDS" | jq -r .username);
+MYSQL_MASTER_PASSWORD=$(echo "$MYSQL_MASTER_CREDS" | jq -r .password);
+MYSQL_OPTIONS="-h $MYSQL_HOST --user=$MYSQL_MASTER_USER --password=$MYSQL_MASTER_PASSWORD"
+
+echo "Creating GRANT/User for User[${MYSQL_USER}] on Database[${MYSQL_DB}]..."
+
+echo "GRANT $MYSQL_PERMISSIONS ON $MYSQL_DB.* TO '$MYSQL_USER'@\`%\` IDENTIFIED BY '$MYSQL_PASSWORD';" | mysql $MYSQL_OPTIONS &> /dev/null
+result=$?
+
+if [ $result -ne 0 ]; then
+  echo "Failed to run command [with exit code ${result} from MySQL]"
+  echo "Redacted command: [GRANT $MYSQL_PERMISSIONS ON $MYSQL_DB.* TO '$MYSQL_USER'@\`%\` IDENTIFIED BY '<PASSWORD REMOVED>';]"
+  exit $result
+else 
+  echo "Successfully updated MySQL."
+fi 

--- a/initContainer/db-iam-user.sh
+++ b/initContainer/db-iam-user.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+MYSQL_MASTER_USER=$(echo "$MYSQL_MASTER_CREDS" | jq -r .username);
+MYSQL_MASTER_PASSWORD=$(echo "$MYSQL_MASTER_CREDS" | jq -r .password);
+MYSQL_OPTIONS="-h $MYSQL_HOST --user=$MYSQL_MASTER_USER --password=$MYSQL_MASTER_PASSWORD"
+
+RWUSER="iamrw"
+ROUSER="iamro"
+
+echo "CREATE USER $RWUSER IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';" | mysql $MYSQL_OPTIONS
+echo "GRANT ALL ON \`%\`.* TO ${RWUSER}@\`%\`;" | mysql $MYSQL_OPTIONS
+
+echo "CREATE USER $ROUSER IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';" | mysql $MYSQL_OPTIONS
+echo "GRANT SELECT ON \`%\`.* TO ${ROUSER}@\`%\`;" | mysql $MYSQL_OPTIONS 


### PR DESCRIPTION
## [1.16.0] - 2020-08-31
### Added
- [Issue-165](https://github.com/ExpediaGroup/apiary-data-lake/issues/165) Add init container dockerfile for supporting air-gapped environments.


Requirement for: https://github.com/ExpediaGroup/apiary-data-lake/issues/165