### PR TITLE
Add codeowners, bugReport, featureRequest, prRequest templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ExpediaGroup/apiary-committers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour ideally including the configuration files you are using (feel free to rename any sensitive information like server and table names etc.)
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+Please add the log output from Apiary when the terraform error occurs, full stack traces are especially useful.
+
+**Versions (please complete the following information):**
+- Apiary Version: 
+- Apiary Init Container Version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example - I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+Thank you for submitting a pull request!
+
+Please verify that:
+* [ ] Code is up-to-date with the `master` branch.
+* [ ] You've successfully built and run the tests locally.
+* [ ] There are new or updated unit tests validating the change.
+
+Refer to CODE-OF-CONDUCT.md for more details.
+  https://github.com/ExpediaGroup/apiary-metastore-docker/blob/master/CODE-OF-CONDUCT.md
+-->
+
+### :pencil: Description
+
+
+### :link: Related Issues


### PR DESCRIPTION
Noticed that we were missing these github meta files on this repo.
Added & copied templates from https://github.com/ExpediaGroup/apiary-data-lake