### PR TITLE
Upgrade EMR repository version to support OIDC web identity token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [3.0.0] - 2022-03-25
 ### Changed
-- Upgrade EMR repository version so `AWS SDK for Java` library is upgraded to `1.11.852` and in that way support authentication using IAM role via an OIDC web identity token file (https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html).
+- Upgrade EMR repository to version `5.30.2` (was `5.24.0`) so `AWS SDK for Java` library is upgraded to `1.11.759` and in that way support authentication using IAM role via an OIDC web identity token file (https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html).
 
 ## [2.0.3] - 2021-12-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2022-03-25
+### Changed
+- Upgrade EMR repository version so `AWS SDK for Java` library is upgraded to `1.11.852` and in that way support authentication using IAM role via an OIDC web identity token file (https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html).
+
 ## [2.0.3] - 2021-12-16
 ### Changed
 - Modified log4j2 security script to reduce container startup time.

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ wget -q https://search.maven.org/remotecontent?filepath=com/kstruct/gethostname4
 wget -q https://search.maven.org/remotecontent?filepath=com/sun/jna/jna/${JNA_VERSION}/jna-${JNA_VERSION}.jar -O jna-${JNA_VERSION}.jar && \
 wget -q https://search.maven.org/remotecontent?filepath=io/prometheus/jmx/jmx_prometheus_javaagent/${EXPORTER_VERSION}/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar -O jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar
 
-
 ENV MAVEN_VERSION 3.6.3
 
 RUN wget -q -O - https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | tar -C /opt -xzf - && \

--- a/files/emr-apps.repo
+++ b/files/emr-apps.repo
@@ -2,6 +2,6 @@
 name = EMR Applications Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.24.0/a536ac12-f2f9-43e2-88ae-1a1e6d740eb9
+baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.31.0/a536ac12-f2f9-43e2-88ae-1a1e6d740eb9
 priority = 5
 gpgcheck = 1

--- a/files/emr-apps.repo
+++ b/files/emr-apps.repo
@@ -2,6 +2,6 @@
 name = EMR Applications Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.31.0/a536ac12-f2f9-43e2-88ae-1a1e6d740eb9
+baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.30.2/68484a08-7f34-4363-bf25-393705f7760f
 priority = 5
 gpgcheck = 1


### PR DESCRIPTION
Upgrade EMR repository version so `AWS SDK for Java` library is upgraded to `1.11.852` and in that way support authentication using IAM role via an OIDC web identity token file (https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html).