### PR TITLE
LDAP Credentials now can be loaded directly using env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.5] - 2022-05-25
+### Changed
+- LDAP Credentials now can be loaded directly using `LDAP_USERNAME` and `LDAP_PASSWORD`, this is useful to load them from Vault.
+
 ## [3.0.4] - 2022-05-24
 ### Changed
 - Upgrade `apiary-gluesync-listener` version to `7.3.0` (was `4.2.0`).

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -33,8 +33,12 @@ fi
 
 #configure LDAP group mapping, required for ranger authorization
 if [[ -n $LDAP_URL ]] ; then
-    update_property.py hadoop.security.group.mapping.ldap.bind.user "$(aws secretsmanager get-secret-value --secret-id ${LDAP_SECRET_ARN}|jq .SecretString -r|jq .username -r)" /etc/hadoop/conf/core-site.xml
-    aws secretsmanager get-secret-value --secret-id ${LDAP_SECRET_ARN}|jq .SecretString -r|jq .password -r > /etc/hadoop/conf/ldap-password.txt
+    if [[ -n $LDAP_SECRET_ARN ]] ; then
+        LDAP_USERNAME="$(aws secretsmanager get-secret-value --secret-id ${LDAP_SECRET_ARN}|jq .SecretString -r|jq .username -r)"
+        LDAP_PASSWORD="$(aws secretsmanager get-secret-value --secret-id ${LDAP_SECRET_ARN}|jq .SecretString -r|jq .password -r)"
+    fi
+    update_property.py hadoop.security.group.mapping.ldap.bind.user "${LDAP_USERNAME}" /etc/hadoop/conf/core-site.xml
+    echo "${LDAP_PASSWORD}" > /etc/hadoop/conf/ldap-password.txt
     update_property.py hadoop.security.group.mapping org.apache.hadoop.security.LdapGroupsMapping /etc/hadoop/conf/core-site.xml
     update_property.py hadoop.security.group.mapping.ldap.url "${LDAP_URL}" /etc/hadoop/conf/core-site.xml
     update_property.py hadoop.security.group.mapping.ldap.base "${LDAP_BASE}" /etc/hadoop/conf/core-site.xml


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-metastore-docker/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues
