### PR TITLE
Added EMR 5.3.61 repo for Hive 2.3.9 (was 2.3.7)  upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). 
 
-## [5.1.0] - 2024-06-2x
+## [5.2.0] - 2024-08-22
+### Added
+- Upgrade HMS to 2.3.9 (was 2.3.7)
+
+## [5.1.0] - 2024-06-24
 ### Added
 - Added `datanucleus.connectionPoolingType` to hive-site.xml, defaults: `BoneCP`
 - Added `DATANUCLEUS_CONNECTION_POOLING_TYPE` to support changing the database connection pooling. Valid options are `BoneCP`, `DBCP`, `DBCP2`, `C3P0`, `HikariCP`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV EXPORTER_VERSION 0.12.0
 COPY files/RPM-GPG-KEY-emr /etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 COPY files/emr-apps.repo /etc/yum.repos.d/emr-apps.repo
 COPY files/emr-platform.repo /etc/yum.repos.d/emr-platform.repo
+COPY files/emr-puppet.repo /etc/yum.repos.d/emr-puppet.repo
 
 RUN yum -y install java-1.8.0-openjdk \
   java-1.8.0-openjdk-devel.x86_64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY files/emr-apps.repo /etc/yum.repos.d/emr-apps.repo
 COPY files/emr-platform.repo /etc/yum.repos.d/emr-platform.repo
 COPY files/emr-puppet.repo /etc/yum.repos.d/emr-puppet.repo
 
+RUN useradd -r hadoop 
 RUN yum -y install java-1.8.0-openjdk \
   java-1.8.0-openjdk-devel.x86_64 \
   hive-metastore \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ COPY files/emr-apps.repo /etc/yum.repos.d/emr-apps.repo
 COPY files/emr-platform.repo /etc/yum.repos.d/emr-platform.repo
 COPY files/emr-puppet.repo /etc/yum.repos.d/emr-puppet.repo
 
-RUN useradd -r hadoop 
+RUN yum -y install shadow-utils && \
+    useradd -r hadoop
 RUN yum -y install java-1.8.0-openjdk \
   java-1.8.0-openjdk-devel.x86_64 \
   hive-metastore \

--- a/files/emr-apps.repo
+++ b/files/emr-apps.repo
@@ -2,6 +2,6 @@
 name = EMR Applications Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.31.0/a75d77c7-f528-4266-b091-275dae889395
+baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/apps-repository/emr-5.36.1/537bc564-6e04-4aae-b93e-5f9efb9d8879
 priority = 5
 gpgcheck = 1

--- a/files/emr-platform.repo
+++ b/files/emr-platform.repo
@@ -2,6 +2,6 @@
 name = EMR Platform Repository
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 enabled = 1
-baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/platform-repository/1.25.0/IC/62a67666-0178-4de0-ad0e-0ff1c00bfbfa
+baseurl = https://s3.amazonaws.com/repo.us-east-1.emr.amazonaws.com/platform-repository/1.30.1/97926b1a-1e1b-4821-a019-71c03fc527ff
 priority = 5
 gpgcheck = 1

--- a/files/emr-puppet.repo
+++ b/files/emr-puppet.repo
@@ -1,0 +1,9 @@
+[emr-puppet]
+name = Amazon Extras repo for emr-puppet
+report_instanceid = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-emr
+enabled = 1
+skip_if_unavailable = 1
+priority = 10
+mirrorlist = http://amazonlinux.$awsregion.$awsdomain/$releasever/extras/emr-puppet/latest/$basearch/mirror.list
+gpgcheck = 1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-metastore-docker/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues
